### PR TITLE
add slot cleanup for legacy

### DIFF
--- a/src/MEVTaxBase.sol
+++ b/src/MEVTaxBase.sol
@@ -30,6 +30,7 @@ abstract contract MEVTaxBase is Ownable {
     modifier applyTax() virtual {
         _applyTax();
         _;
+        _afterApplyTax();
     }
 
     /// @dev Sets the deployer as the initial owner.
@@ -79,6 +80,9 @@ abstract contract MEVTaxBase is Ownable {
             SafeTransferLib.safeTransferFrom(currency, msg.sender, recipient, taxAmount);
         }
     }
+
+    /// @notice After applying the tax, performs any necessary cleanup.
+    function _afterApplyTax() internal virtual {}
 
     /// @notice Returns the current priority fee per gas.
     /// @return Priority fee per gas.

--- a/src/legacy/MEVTax.sol
+++ b/src/legacy/MEVTax.sol
@@ -21,4 +21,9 @@ contract MEVTax is MEVTaxBase {
     function _updateMsgValueDelta(uint256 _delta) internal override {
         Storage.setUint(MSG_VALUE_DELTA_SLOT, _msgValueDelta() + _delta);
     }
+
+    /// @notice After applying the tax, resets the slot to zero.
+    function _afterApplyTax() internal override {
+        Storage.setUint(MSG_VALUE_DELTA_SLOT, 0);
+    }
 }

--- a/test/MEVTax.t.sol
+++ b/test/MEVTax.t.sol
@@ -20,13 +20,6 @@ contract MEVTaxWithTaxApplied is MEVTax {
     function mockTax() external payable applyTax {}
 }
 
-/// @title MEVTaxWithTaxAppliedLegacy
-/// @notice This contract exposes a function with the applyTax modifier.
-contract MEVTaxWithTaxAppliedLegacy is MEVTax {
-    /// @notice Mock function that applies the tax.
-    function mockTax() external payable applyTax {}
-}
-
 contract MEVTaxTest is Test {
     address mockCurrency;
     address mockRecipient;

--- a/test/MEVTaxLegacy.t.sol
+++ b/test/MEVTaxLegacy.t.sol
@@ -9,55 +9,48 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
 // Target contract dependencies
-import {MEVTax} from "../src/MEVTax.sol";
+import {MEVTax} from "../src/legacy/MEVTax.sol";
 import {MEVTaxBase} from "../src/MEVTaxBase.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title MEVTaxWithTaxApplied
-/// @notice This contract exposes a function with the applyTax modifier.
-contract MEVTaxWithTaxApplied is MEVTax {
-    /// @notice Mock function that applies the tax.
-    function mockTax() external payable applyTax {}
-}
-
-/// @title MEVTaxWithTaxAppliedLegacy
 /// @notice This contract exposes a function with the applyTax modifier.
 contract MEVTaxWithTaxAppliedLegacy is MEVTax {
     /// @notice Mock function that applies the tax.
     function mockTax() external payable applyTax {}
 }
 
-contract MEVTaxTest is Test {
+contract MEVTaxLegacyTest is Test {
     address mockCurrency;
     address mockRecipient;
-    MEVTaxWithTaxApplied public mevTax;
+    MEVTaxWithTaxAppliedLegacy public mevTaxLegacy;
 
     function setUp() public {
         mockCurrency = address(new ERC20Mock());
         mockRecipient = address(0x2);
-        mevTax = new MEVTaxWithTaxApplied();
-        mevTax.setCurrency(mockCurrency);
-        mevTax.setRecipient(mockRecipient);
+        mevTaxLegacy = new MEVTaxWithTaxAppliedLegacy();
+        mevTaxLegacy.setCurrency(mockCurrency);
+        mevTaxLegacy.setRecipient(mockRecipient);
     }
 
     /// @dev Tests that the currency can be updated by the owner.
     function testFuzz_setCurrency_owner_succeeds(address _currencyAddress) public {
-        mevTax.setCurrency(_currencyAddress);
-        assertEq(mevTax.currency(), _currencyAddress);
+        mevTaxLegacy.setCurrency(_currencyAddress);
+        assertEq(mevTaxLegacy.currency(), _currencyAddress);
     }
 
     /// @dev Tests that the currency cannot be updated by a non-owner.
     function testFuzz_setCurrency_notOwner_reverts(address _currencyAddress) public {
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0)));
         vm.prank(address(0));
-        mevTax.setCurrency(_currencyAddress);
+        mevTaxLegacy.setCurrency(_currencyAddress);
     }
 
     /// @dev Tests that the recipient can be successfully updated by the owner
     ///      for arbitrary address _recipient.
     function testFuzz_setRecipient_owner_succeeds(address _recipient) public {
-        mevTax.setRecipient(_recipient);
-        assertEq(mevTax.recipient(), _recipient);
+        mevTaxLegacy.setRecipient(_recipient);
+        assertEq(mevTaxLegacy.recipient(), _recipient);
     }
 
     /// @dev Tests that the recipient cannot be updated by a non-owner for
@@ -65,23 +58,23 @@ contract MEVTaxTest is Test {
     function testFuzz_setRecipient_notOwner_reverts(address _recipient) public {
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0)));
         vm.prank(address(0));
-        mevTax.setRecipient(_recipient);
+        mevTaxLegacy.setRecipient(_recipient);
     }
 
     /// @dev Tests that isCurrencyETH returns correctly for native currency.
     function test_isCurrencyETH_native_succeeds() public {
-        assertFalse(mevTax.isCurrencyETH());
-        testFuzz_setCurrency_owner_succeeds(mevTax.ETH_CURRENCY());
-        assertTrue(mevTax.isCurrencyETH());
+        assertFalse(mevTaxLegacy.isCurrencyETH());
+        testFuzz_setCurrency_owner_succeeds(mevTaxLegacy.ETH_CURRENCY());
+        assertTrue(mevTaxLegacy.isCurrencyETH());
     }
 
     /// @dev Tests that isCurrecyETH returns correctly for non-native currency.
     function testFuzz_isCurrencyETH_nonNative_succeeds(address _currencyAddress) public {
-        vm.assume(_currencyAddress != mevTax.ETH_CURRENCY());
-        testFuzz_setCurrency_owner_succeeds(mevTax.ETH_CURRENCY());
-        assertTrue(mevTax.isCurrencyETH());
+        vm.assume(_currencyAddress != mevTaxLegacy.ETH_CURRENCY());
+        testFuzz_setCurrency_owner_succeeds(mevTaxLegacy.ETH_CURRENCY());
+        assertTrue(mevTaxLegacy.isCurrencyETH());
         testFuzz_setCurrency_owner_succeeds(_currencyAddress);
-        assertFalse(mevTax.isCurrencyETH());
+        assertFalse(mevTaxLegacy.isCurrencyETH());
     }
 
     /// @dev Tests that mockTax succeeds when _amount of mockCurrency is
@@ -101,12 +94,12 @@ contract MEVTaxTest is Test {
         vm.txGasPrice(_txGasPrice);
         vm.fee(_baseFee);
         // calculate the tax amount
-        uint256 taxAmount = mevTax.tax(priorityFeePerGas);
+        uint256 taxAmount = mevTaxLegacy.tax(priorityFeePerGas);
         // bound the amount to be equal or greater than the tax amount
         _amount = bound(_amount, taxAmount, type(uint256).max);
 
         // set currency to native ether
-        mevTax.setCurrency(mevTax.ETH_CURRENCY());
+        mevTaxLegacy.setCurrency(mevTaxLegacy.ETH_CURRENCY());
 
         // mint the amount
         // since _amount is greater than the tax amount, the tax will be paid
@@ -114,7 +107,7 @@ contract MEVTaxTest is Test {
         assertEq(address(this).balance, _amount);
 
         // apply the tax
-        mevTax.mockTax{value: _amount}();
+        mevTaxLegacy.mockTax{value: _amount}();
 
         // check that the tax was paid
         assertEq(address(mockRecipient).balance, taxAmount);
@@ -137,7 +130,7 @@ contract MEVTaxTest is Test {
         vm.txGasPrice(_txGasPrice);
         vm.fee(_baseFee);
         // calculate the tax amount
-        uint256 taxAmount = mevTax.tax(priorityFeePerGas);
+        uint256 taxAmount = mevTaxLegacy.tax(priorityFeePerGas);
         // bound the amount to be equal or greater than the tax amount
         _amount = bound(_amount, taxAmount, type(uint256).max);
 
@@ -147,7 +140,7 @@ contract MEVTaxTest is Test {
         assertEq(IERC20(mockCurrency).balanceOf(address(this)), _amount);
 
         // apply the tax
-        mevTax.mockTax();
+        mevTaxLegacy.mockTax();
 
         // check that the tax was paid
         assertEq(IERC20(mockCurrency).balanceOf(address(this)), _amount - taxAmount);
@@ -171,20 +164,20 @@ contract MEVTaxTest is Test {
         vm.txGasPrice(_txGasPrice);
         vm.fee(_baseFee);
         // calculate the tax amount
-        uint256 taxAmount = mevTax.tax(priorityFeePerGas);
+        uint256 taxAmount = mevTaxLegacy.tax(priorityFeePerGas);
         // bound the paid amount to be less than the tax amount
         vm.assume(taxAmount > 0);
         _amount = bound(_amount, 0, taxAmount - 1);
 
         // set currency to native ether
-        mevTax.setCurrency(mevTax.ETH_CURRENCY());
+        mevTaxLegacy.setCurrency(mevTaxLegacy.ETH_CURRENCY());
 
         // mint the amount
         // since _amount is greater than the tax amount, the tax will be paid
         vm.deal(address(this), _amount);
 
         vm.expectRevert(MEVTaxBase.InsufficientMsgValue.selector);
-        mevTax.mockTax{value: _amount}();
+        mevTaxLegacy.mockTax{value: _amount}();
     }
 
     /// @dev Tests that mockTax reverts when _amount of mockCurrency is
@@ -204,7 +197,7 @@ contract MEVTaxTest is Test {
         vm.txGasPrice(_txGasPrice);
         vm.fee(_baseFee);
         // calculate the tax amount
-        uint256 taxAmount = mevTax.tax(priorityFeePerGas);
+        uint256 taxAmount = mevTaxLegacy.tax(priorityFeePerGas);
         // bound the paid amount to be less than the tax amount
         vm.assume(taxAmount > 0);
         _amount = bound(_amount, 0, taxAmount - 1);
@@ -216,7 +209,7 @@ contract MEVTaxTest is Test {
         assertEq(IERC20(mockCurrency).balanceOf(address(this)), _amount);
 
         vm.expectRevert();
-        mevTax.mockTax();
+        mevTaxLegacy.mockTax();
     }
 
     /// @dev Internal helper function to mint an arbitrary _amount of
@@ -224,6 +217,6 @@ contract MEVTaxTest is Test {
     ///      to spend the minted amount.
     function _mintAndApprove(uint256 _amount) internal {
         ERC20Mock(mockCurrency).mint(address(this), _amount);
-        ERC20Mock(mockCurrency).approve(address(mevTax), _amount);
+        ERC20Mock(mockCurrency).approve(address(mevTaxLegacy), _amount);
     }
 }


### PR DESCRIPTION
**Description**

add `_afterApplyTax` function in modifier to cleanup slot for legacy contract.

**Tests**

add `MEVTaxLegacyTest.t.sol` test file

**Additional context**