### PR TITLE
Introduce MevTaxLib and MEVTaxBase Contracts

### DIFF
--- a/src/MEVTax.sol
+++ b/src/MEVTax.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {MEVTaxBase} from "src/MEVTaxBase.sol";
-import {TransientContext} from "transience/TransientContext.sol";
+import {MEVTaxBase, MevTaxLib} from "src/library/MevTaxLib.sol";
 
 /// @title  MEVTax
 /// @notice This contract should be inherited by contracts to apply a MEV tax.
@@ -10,15 +9,24 @@ import {TransientContext} from "transience/TransientContext.sol";
 ///         gas of the transaction.
 /// @dev    This contract uses transient storage to store the delta for msg.value.
 contract MEVTax is MEVTaxBase {
-    /// @notice Returns the magnitude of the negative delta to account for
-    ///         subtractions to msg.value.
-    function _msgValueDelta() internal view override returns (uint256) {
-        return TransientContext.get(MSG_VALUE_DELTA_SLOT);
+    /// @notice inherits from MEVTaxBase
+    /// @return output of the tax function (the tax amount for _priorityFeePerGas).
+    function getTaxAmount() internal view virtual override returns (uint256) {
+        return tax(_currentPriorityFeePerGas());
     }
 
-    /// @notice Updates the magnitude of the negative delta to account for
-    ///         a change in msg.value.
-    function _updateMsgValueDelta(uint256 _delta) internal override {
-        TransientContext.set(MSG_VALUE_DELTA_SLOT, _msgValueDelta() + _delta);
+    /// @notice Returns the current priority fee per gas.
+    /// @return Priority fee per gas.
+    function _currentPriorityFeePerGas() internal view returns (uint256) {
+        return tx.gasprice - block.basefee;
+    }
+
+    /// @notice Computes the tax function for a _priorityFeePerGas.
+    ///         Unless overridden, it is 99 times the priority fee per gas.
+    /// @dev    Override this function to implement a custom tax function.
+    /// @param  _priorityFeePerGas Priority fee per gas to input to the tax function.
+    /// @return Output of the tax function (the tax amount for _priorityFeePerGas).
+    function tax(uint256 _priorityFeePerGas) public view virtual returns (uint256) {
+        return 99 * _priorityFeePerGas;
     }
 }

--- a/src/legacy/MEVTaxLegacy.sol
+++ b/src/legacy/MEVTaxLegacy.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import {MEVTaxBase} from "src/MEVTaxBase.sol";
+import {MEVTaxLegacyBase} from "src/legacy/MEVTaxLegacyBase.sol";
 import {Storage} from "optimism/libraries/Storage.sol";
 
-/// @title  MEVTax
+/// @title  MEVTaxLegacy
 /// @notice This contract should be inherited by contracts to apply a MEV tax.
 ///         The tax amount is calculated as a function of the priority fee per
 ///         gas of the transaction.
 /// @dev    This contract uses regular storage to store the delta for msg.value.
-contract MEVTax is MEVTaxBase {
+contract MEVTaxLegacy is MEVTaxLegacyBase {
     /// @notice Returns the magnitude of the negative delta to account for
     ///         subtractions to msg.value.
     function _msgValueDelta() internal view override returns (uint256) {

--- a/src/legacy/MEVTaxLegacyBase.sol
+++ b/src/legacy/MEVTaxLegacyBase.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.13;
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 
-/// @title MEVTaxBase
-abstract contract MEVTaxBase is Ownable {
+/// @title MEVTaxLegacyBase
+abstract contract MEVTaxLegacyBase is Ownable {
     /// @notice Thrown when the value of the transaction is insufficient.
     error InsufficientMsgValue();
 

--- a/src/library/MevTaxLib.sol
+++ b/src/library/MevTaxLib.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
+import {TransientContext} from "transience/TransientContext.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+library MevTaxLib {
+    /// @notice Slot for the delta to account for updates to msg.value.
+    bytes32 public constant MSG_VALUE_DELTA_SLOT = keccak256("MEVTax._msgValueDelta");
+    /// @notice Currency for paying the tax in native ether.
+    address public constant ETH_CURRENCY = address(0);
+    
+    /// @notice Transfers the tax amount in native ether or ERC20 to the recipient.
+    function transferTax(address currency, address from, address recipient, uint256 taxAmount) internal {
+        if (currency == ETH_CURRENCY) {
+            SafeTransferLib.safeTransferETH(recipient, taxAmount);
+            _updateMsgValueDelta(getMsgValueDelta() + taxAmount);
+        } else {
+            SafeTransferLib.safeTransferFrom(currency, from, recipient, taxAmount);
+        }
+    }
+
+    /// @notice Updates the magnitude of the negative delta to account for
+    ///         a change in msg.value.
+    function _updateMsgValueDelta(uint256 delta) internal {
+        TransientContext.set(MSG_VALUE_DELTA_SLOT, delta);
+    }
+
+    /// @notice Returns the magnitude of the negative delta to account for
+    ///         subtractions to msg.value.
+    function getMsgValueDelta() internal view returns (uint256) {
+        return TransientContext.get(MSG_VALUE_DELTA_SLOT);
+    }
+}
+
+abstract contract MEVTaxBase is Ownable {
+    /// @notice Thrown when the value of the transaction is insufficient.
+    error InsufficientMsgValue();
+
+    /// @notice Thrown when the magnitude of the negative delta to account for
+    ///         subtractions to msg.value is greater than msg.value.
+    error DeltaAdjustedMsgValueUnderflow();
+
+    /// @notice Currency for paying the tax.
+    address public currency = MevTaxLib.ETH_CURRENCY;
+
+    /// @notice Recipient of the tax transfers.
+    address public recipient = address(this);
+
+    /// @notice Modifier to apply tax on a function.
+    ///         If applying the tax fails, the modifier reverts.
+    modifier applyTax() virtual{
+        _applyTax();
+        _;
+    }
+
+    /// @notice Applies tax at the transaction's priority fee per gas.
+    ///         If the transfer fails, the function reverts.
+    function _applyTax() internal {
+        uint256 taxAmount = getTaxAmount();
+        if (isCurrencyETH() && _msgValue() < taxAmount) {
+            revert InsufficientMsgValue();
+        }
+        MevTaxLib.transferTax(currency, msg.sender, recipient, taxAmount);
+    }
+
+    /// @dev Sets the deployer as the initial owner.
+    constructor() Ownable(msg.sender) {}
+
+    /// @notice Returns whether the currency is native ether.
+    /// @return True if the currency is native ether, and false otherwise.
+    function isCurrencyETH() public view returns (bool) {
+        return currency == MevTaxLib.ETH_CURRENCY;
+    }
+
+    /// @notice Sets the currency to _currency.
+    /// @param _currency Address of the currency to set.
+    function setCurrency(address _currency) external onlyOwner {
+        currency = _currency;
+    }
+
+    /// @notice Sets the recipient to _recipient.
+    /// @param _recipient Address of the recipient to set.
+    function setRecipient(address _recipient) external onlyOwner {
+        recipient = _recipient;
+    }
+
+    /// @notice Returns the dynamic value of the transaction, accounting for
+    ///         subtractions to msg.value.
+    /// @return Delta-adjusted value of the transaction.
+    function _msgValue() internal view virtual returns (uint256) {
+        uint256 delta = MevTaxLib.getMsgValueDelta();
+        if (msg.value < delta) revert DeltaAdjustedMsgValueUnderflow();
+        return msg.value - delta;
+    }
+
+    /// @notice Returns the tax amount for the transaction.
+    function getTaxAmount() internal view virtual returns (uint256);
+}

--- a/test/MEVTax.t.sol
+++ b/test/MEVTax.t.sol
@@ -10,7 +10,7 @@ import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
 // Target contract dependencies
 import {MEVTax} from "../src/MEVTax.sol";
-import {MEVTaxBase} from "../src/MEVTaxBase.sol";
+import {MEVTaxBase, MevTaxLib} from "../src/library/MevTaxLib.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title MEVTaxWithTaxApplied
@@ -64,14 +64,14 @@ contract MEVTaxTest is Test {
     /// @dev Tests that isCurrencyETH returns correctly for native currency.
     function test_isCurrencyETH_native_succeeds() public {
         assertFalse(mevTax.isCurrencyETH());
-        testFuzz_setCurrency_owner_succeeds(mevTax.ETH_CURRENCY());
+        testFuzz_setCurrency_owner_succeeds(MevTaxLib.ETH_CURRENCY);
         assertTrue(mevTax.isCurrencyETH());
     }
 
     /// @dev Tests that isCurrecyETH returns correctly for non-native currency.
     function testFuzz_isCurrencyETH_nonNative_succeeds(address _currencyAddress) public {
-        vm.assume(_currencyAddress != mevTax.ETH_CURRENCY());
-        testFuzz_setCurrency_owner_succeeds(mevTax.ETH_CURRENCY());
+        vm.assume(_currencyAddress != MevTaxLib.ETH_CURRENCY);
+        testFuzz_setCurrency_owner_succeeds(MevTaxLib.ETH_CURRENCY);
         assertTrue(mevTax.isCurrencyETH());
         testFuzz_setCurrency_owner_succeeds(_currencyAddress);
         assertFalse(mevTax.isCurrencyETH());
@@ -99,7 +99,7 @@ contract MEVTaxTest is Test {
         _amount = bound(_amount, taxAmount, type(uint256).max);
 
         // set currency to native ether
-        mevTax.setCurrency(mevTax.ETH_CURRENCY());
+        mevTax.setCurrency(MevTaxLib.ETH_CURRENCY);
 
         // mint the amount
         // since _amount is greater than the tax amount, the tax will be paid
@@ -170,7 +170,7 @@ contract MEVTaxTest is Test {
         _amount = bound(_amount, 0, taxAmount - 1);
 
         // set currency to native ether
-        mevTax.setCurrency(mevTax.ETH_CURRENCY());
+        mevTax.setCurrency(MevTaxLib.ETH_CURRENCY);
 
         // mint the amount
         // since _amount is greater than the tax amount, the tax will be paid

--- a/test/MEVTaxLegacy.t.sol
+++ b/test/MEVTaxLegacy.t.sol
@@ -9,13 +9,13 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
 // Target contract dependencies
-import {MEVTax} from "../src/legacy/MEVTax.sol";
-import {MEVTaxBase} from "../src/MEVTaxBase.sol";
+import {MEVTaxLegacy} from "../src/legacy/MEVTaxLegacy.sol";
+import {MEVTaxLegacyBase} from "../src/legacy/MEVTaxLegacyBase.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @title MEVTaxWithTaxApplied
 /// @notice This contract exposes a function with the applyTax modifier.
-contract MEVTaxWithTaxAppliedLegacy is MEVTax {
+contract MEVTaxWithTaxAppliedLegacy is MEVTaxLegacy {
     /// @notice Mock function that applies the tax.
     function mockTax() external payable applyTax {}
 }
@@ -176,7 +176,7 @@ contract MEVTaxLegacyTest is Test {
         // since _amount is greater than the tax amount, the tax will be paid
         vm.deal(address(this), _amount);
 
-        vm.expectRevert(MEVTaxBase.InsufficientMsgValue.selector);
+        vm.expectRevert(MEVTaxLegacyBase.InsufficientMsgValue.selector);
         mevTaxLegacy.mockTax{value: _amount}();
     }
 


### PR DESCRIPTION
## Description
1. `MevTaxLegacy` Refactor
- moved `MevTaxLegacy` related implementations to src/legacy.

2. `MevTaxLib` Implementations
- added `MevTaxLib` library based on the TransientContext
- created `MEVTaxBase` abstract contract utilizing `MevTaxLib` to standardize mev tax.